### PR TITLE
Upate package.json and spec for TravisCI node-v10 error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ language: node_js
 node_js:
 - 6.10
 - 8.11
-- 10.6
+- 10.4
+# mock-fsが node v10.5以上で、fs.promiseのcallbackが動作しないため、暫定として10.4を指定

--- a/package.json
+++ b/package.json
@@ -25,21 +25,21 @@
     "package.json"
   ],
   "devDependencies": {
-    "del": "~1.1.1",
+    "del": "~3.0.0",
     "gulp": "~3.9.1",
-    "gulp-istanbul": "~0.10.4",
+    "gulp-istanbul": "~1.1.3",
     "gulp-jasmine": "~2.3.0",
     "gulp-shell": "~0.5.2",
-    "gulp-tslint": "~4.3.5",
+    "gulp-tslint": "~8.1.3",
     "jasmine": "~2.1.1",
     "jasmine-reporters": "~2.0.4",
     "jasmine-terminal-reporter": "~0.9.1",
     "mdast": "~2.0.0",
     "mdast-lint": "~1.1.1",
-    "mock-fs": "~4.4.2",
-    "tslint": "~3.7.4",
-    "typescript": "1.7.5",
-    "typings": "1.0.4"
+    "mock-fs": "~4.7.0",
+    "tslint": "~5.11.0",
+    "typescript": "~2.6.1",
+    "typings": "2.1.1"
   },
   "dependencies": {
     "@akashic/akashic-cli-commons": "~0.2.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jasmine-terminal-reporter": "~0.9.1",
     "mdast": "~2.0.0",
     "mdast-lint": "~1.1.1",
-    "mock-fs": "~4.7.0",
+    "mock-fs": "~4.5.0",
     "tslint": "~5.11.0",
     "typescript": "~2.6.1",
     "typings": "2.1.1"

--- a/spec/src/ConfigurationSpec.ts
+++ b/spec/src/ConfigurationSpec.ts
@@ -4,7 +4,7 @@ import { Configuration } from "../../lib/Configuration";
 describe("Configuration", function () {
 	describe("#removeOperationPlugin()", function () {
 		it("removes declaration", function () {
-			var logger = new cmn.ConsoleLogger({ debugLogMethod: () => {/* do nothing*/} })
+			var logger = new cmn.ConsoleLogger({ debugLogMethod: () => {/* do nothing*/} });
 			var content = {
 				width: 120,
 				height: 120,
@@ -12,19 +12,19 @@ describe("Configuration", function () {
 				operationPlugins: [
 					{ code: 10, script: "foo" },
 					{ code: 12, script: "bar" },
-					{ code: 8, script: "anotherScript", options: { optvalue: true } },
+					{ code: 8, script: "anotherScript", options: { optvalue: true } }
 				]
 			};
 			var self = new Configuration({ content, logger });
 			self.removeOperationPlugin("bar@0.2");
 			expect(self.getContent().operationPlugins).toEqual([
 				{ code: 10, script: "foo" },
-				{ code: 8, script: "anotherScript", options: { optvalue: true } },
+				{ code: 8, script: "anotherScript", options: { optvalue: true } }
 			]);
 		});
 
 		it("nothing removed for module not declared in operationPlugins", function () {
-			var logger = new cmn.ConsoleLogger({ debugLogMethod: () => {/* do nothing*/} })
+			var logger = new cmn.ConsoleLogger({ debugLogMethod: () => {/* do nothing*/} });
 			var content = { width: 120, height: 120, fps: 30 };
 			var self = new Configuration({ content, logger });
 			self.removeOperationPlugin("foo");

--- a/spec/src/uninstallSpec.ts
+++ b/spec/src/uninstallSpec.ts
@@ -2,23 +2,24 @@ import * as mockfs from "mock-fs";
 import * as cmn from "@akashic/akashic-cli-commons";
 import { uninstall, promiseUninstall } from "../../lib/uninstall";
 
+
 describe("uninstall()", function () {
 	afterEach(function () {
 		mockfs.restore();
 	});
 
-	it("rejects multiple module names if plugin opetion is given", function (done) {
+	it("rejects multiple module names if plugin opetion is given",  function (done: any) {
 		mockfs({});
 		uninstall({ moduleNames: ["foo", "bar"], plugin: true }, (err) => (err ? done() : done.fail()));
 	});
 
-	it("handles npm failure", function (done) {
+	it("handles npm failure", (done: any) => {
 		mockfs({});
 		var shrinkwrapCalled = false;
 		class DummyNpm extends cmn.PromisedNpm {
 			uninstall(names?: string[]) { return Promise.reject("UninstallFail:" + names); }
 			shrinkwrap(names?: string[]) { shrinkwrapCalled = true; return Promise.resolve(); }
-		};
+		}
 		var logger = new cmn.ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
 		Promise.resolve()
 			.then(() => promiseUninstall({
@@ -30,7 +31,7 @@ describe("uninstall()", function () {
 			.then(done.fail, done);
 	});
 
-	it("removes declaration from globalScripts", function (done) {
+	it("removes declaration from globalScripts", function (done: any) {
 		const mockfsContent: any = {
 			testdir: {
 				foo: {
@@ -50,7 +51,7 @@ describe("uninstall()", function () {
 								version: "0.0.0",
 								dependencies: "bar",
 								main: "lib/index.js"
-							}),
+							})
 						},
 						buzz: {
 							sub: {
@@ -62,7 +63,7 @@ describe("uninstall()", function () {
 								version: "0.0.0",
 								dependencies: "sub",
 								main: "main.js"
-							}),
+							})
 						}
 					},
 					"game.json": JSON.stringify({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@ function cli(param: CommandParameterObject): void {
 			logger.error(err, err.cause);
 			process.exit(1);
 		});
-};
+}
 
 var ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")).version;
 


### PR DESCRIPTION
## このpull requestが解決する内容

TravisCIのnode v10でエラーとなる問題の修正
 - 必要モジュールのversionを更新
 - specのlint対応
 - .travis.yml のnodeのv10系の指定を10.4へ修正
     - mock-fsにてnode v10.5以上の場合、fs.Promiseのcallbackが動作しない問題があるため

ロジック自体には影響がないため、セルフマージとする。